### PR TITLE
fix: cast aliases to str before sorting to prevent TypeError with ComputedNameType

### DIFF
--- a/custom_components/xai_conversation/helpers/tool_orchestrator.py
+++ b/custom_components/xai_conversation/helpers/tool_orchestrator.py
@@ -173,7 +173,7 @@ def _get_exposed_entities_with_aliases(
 
         # 2. Enrich Aliases
         if entry and entry.aliases:
-            entity_data_copy["aliases"] = sorted(list(entry.aliases))
+            entity_data_copy["aliases"] = sorted(str(a) for a in entry.aliases)
 
         enriched_entities.append(entity_data_copy)
 
@@ -406,7 +406,7 @@ class ToolOrchestrator:
 
         for entity in self._cached_enriched_entities:
             aliases = entity.get("aliases", [])
-            aliases_str = "/".join(sorted(aliases)) if aliases else ""
+            aliases_str = "/".join(sorted(str(a) for a in aliases)) if aliases else ""
             writer.writerow(
                 [entity.get("entity_id", ""), entity.get("name", ""), aliases_str]
             )


### PR DESCRIPTION
## Problem

After upgrading to HA Core 2026.4.x, `tool_orchestrator.py` crashes when building the entity tool list:

```
TypeError: '<' not supported between instances of 'str' and 'ComputedNameType'
```

**Root cause:** HA 2026.4.x introduced `ComputedNameType` objects in `entity_registry.RegistryEntry.aliases`. The existing code calls `sorted(list(entry.aliases))` which fails because `ComputedNameType` and `str` are not directly comparable with `<`.

This breaks **all** HA tool calls (Intelligent Pipeline and Tool Control), making the integration non-functional for smart home control.

**Traceback:**
```
File "custom_components/xai_conversation/helpers/tool_orchestrator.py", line 176, in _get_exposed_entities_with_aliases
    entity_data_copy["aliases"] = sorted(list(entry.aliases))
TypeError: '<' not supported between instances of 'str' and 'ComputedNameType'
```

## Fix

Cast each alias to `str` before sorting at both locations in `tool_orchestrator.py`:

- **Line 176** (`_get_exposed_entities_with_aliases`): `sorted(list(entry.aliases))` → `sorted(str(a) for a in entry.aliases)`
- **Line 409** (`_build_entity_csv`): `sorted(aliases)` → `sorted(str(a) for a in aliases)`

## Testing

- Verified the fix resolves the `TypeError` on HA 2026.4.1
- No behavioral change for standard `str` aliases — `str()` on a string is a no-op